### PR TITLE
Default title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" href="<%= BASE_URL %>icon.svg">
     <link rel=manifest href="<%= BASE_URL %>manifest.webmanifest">
     <script src="<%= BASE_URL %>env.js"></script>
-    <title></title>
+    <title>Airsonic</title>
   </head>
   <body>
     <noscript>

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -422,7 +422,7 @@ export class API {
         artistId: null,
         image,
         url: episode.streamId ? this.getStreamUrl(episode.streamId) : null,
-        description: podcast.description,
+        description: episode.description,
         playable: episode.status === 'completed',
       })),
     }


### PR DESCRIPTION
Setting a default title for the app, so that you don't see, for example, "192.168.1.2/podcast/7" in the browser title.